### PR TITLE
WIP: Implement Google Login

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,20 +5,28 @@ import (
 	"flag"
 	"log"
 
-	"github.com/kubermatic/tail/pkg/handler"
-
 	"cloud.google.com/go/storage"
+	"github.com/kubermatic/tail/pkg/handler"
 )
 
 var (
-	bucketName, cacheDir, listenPort string
+	bucketName, cacheDir, listenPort, clientID, clientSecret string
 )
 
 func main() {
 	flag.StringVar(&bucketName, "bucket-name", "prow-data", "Name of the bucket")
 	flag.StringVar(&cacheDir, "cache-dir", "./", "The directory to use for caching")
 	flag.StringVar(&listenPort, "listen-port", ":5000", "Port to listen on")
+	flag.StringVar(&clientID, "client-id", "", "Google Client ID")
+	flag.StringVar(&clientSecret, "client-secret", "", "Google Client Secret")
 	flag.Parse()
+
+	if len(clientID) == 0 {
+		log.Fatalf("client-id cannot be empty")
+	}
+	if len(clientSecret) == 0 {
+		log.Fatalf("client-secret cannot be empty")
+	}
 
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
@@ -27,7 +35,7 @@ func main() {
 	}
 
 	bkt := client.Bucket(bucketName)
-	server := handler.New(bkt, cacheDir, listenPort)
+	server := handler.New(bkt, cacheDir, listenPort, clientID, clientSecret)
 
 	log.Printf("Starting to listen on %s", listenPort)
 	if err := server.ListenAndServe(); err != nil {

--- a/login-page.html
+++ b/login-page.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tail</title>
+    <style>
+        a.button {
+            text-decoration: none;
+        }
+    </style>
+</head>
+
+<body>
+    <a href="/login" class="button">Login with Google</a>
+</body>
+
+</html>


### PR DESCRIPTION
Doesn't really do much yet and there are lots of TODOs left, but wanted to create the PR to check if this is the idea that we want to have behind auth:

- User visits `/logs/...`:
  - Is the user logged in?
      - Yes -> Handle the request. TODO: Use the email to check if the user can access this bucket or not
      - No -> Proceed to login page.
        - At the login page, log in via Google. After successfully logging in, redirect to the old `/logs/...` URL.
- To logout visit the `/logout` page. This will destroy the user's session.
