### PR TITLE
Don't use auth for the hook endpoint

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -72,12 +72,7 @@ func (pbh *prowBucketHandler) router(resp http.ResponseWriter, req *http.Request
 		return
 	}
 
-	if req.URL.Path != "/" {
-		http.NotFound(resp, req)
-		return
-	}
-
-	if !isAuthenticated(req) {
+	if req.URL.Path == "/" && !isAuthenticated(req) {
 		tmpl, err := template.ParseFiles("pkg/handler/login.html")
 		if err != nil {
 			log.Print(err)


### PR DESCRIPTION
The `/hook` endpoint is used by Prow for webhooks.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
