### PR TITLE
Fix location of login.html file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,4 @@ RUN apk add --no-cache ca-certificates
 USER nobody
 
 COPY tail /usr/local/bin
+COPY pkg/handler/login.html /var/tmp

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -78,7 +78,7 @@ func (pbh *prowBucketHandler) router(resp http.ResponseWriter, req *http.Request
 	}
 
 	if !isAuthenticated(req) {
-		tmpl, err := template.ParseFiles("pkg/handler/login.html")
+		tmpl, err := template.ParseFiles("/var/tmp/login.html")
 		if err != nil {
 			log.Print(err)
 		}
@@ -112,7 +112,8 @@ func (pbh *prowBucketHandler) handleLogRequest(resp http.ResponseWriter, req *ht
 	}
 
 	if !contains(pbh.publicRepos, repo) && !isAuthenticated(req) {
-		tmpl, err := template.ParseFiles("pkg/handler/login.html")
+		log.Printf("%s is not in the list of public repos %v", repo, pbh.publicRepos)
+		tmpl, err := template.ParseFiles("/var/tmp/login.html")
 		if err != nil {
 			log.Print(err)
 		}


### PR DESCRIPTION
`login.html` file needs to be copied because `pkg/handler/login.html` will only work locally. :/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
